### PR TITLE
plaintext

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "online_editor": {
         "indent_style": "space",
         "indent_size": 2,
-        "highlightjs_language": "TODO: specify highlightjs language"
+        "highlightjs_language": "plaintext"
     },
     "test_runner": {
         "average_run_time": 2.0


### PR DESCRIPTION
highlight.js doesn't support 8th, forth or even, strangely, postscript