### PR TITLE
Reword instructions.append.md (#90)

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -5,10 +5,10 @@
 Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the PATH environment variable.
  
 ### From a REPL
- 
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f acronym-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from acronym-tests.8th or by entering your own. 
+
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"acronym.8th" f:include`
+and you can run tests interactively by copying and pasting them in from acronym-tests.8th or by entering your own. 
  
 ### Editing the acronym-tests.8th file
  

--- a/exercises/practice/acronym/.docs/instructions.append.md
+++ b/exercises/practice/acronym/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
 
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"acronym.8th" f:include`
-and you can run tests interactively by copying and pasting them in from acronym-tests.8th or by entering your own. 
+and you can run the tests with `"acronym-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the acronym-tests.8th file
  

--- a/exercises/practice/acronym/acronym-tests.8th
+++ b/exercises/practice/acronym/acronym-tests.8th
@@ -8,4 +8,3 @@
 "from phrases with consecutive delimiters" "SIMUFTA" ( "Something - I made up from thin air" acronym ) test_eqs
 "from phrases with underscore emphasis" "TRNT" ( "The Road _Not_ Taken" acronym ) test_eqs
 
-bye

--- a/exercises/practice/acronym/test.8th
+++ b/exercises/practice/acronym/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "acronym.8th" dup . cr f:include
 "acronym-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"affine-cipher.8th" f:include`
-and you can run tests interactively by copying and pasting them in from affine-cipher-tests.8th or by entering your own. 
+and you can run the tests with `"affine-cipher-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the affine-cipher-tests.8th file
  

--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f affine-cipher-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from affine-cipher-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"affine-cipher.8th" f:include`
+and you can run tests interactively by copying and pasting them in from affine-cipher-tests.8th or by entering your own. 
  
 ### Editing the affine-cipher-tests.8th file
  

--- a/exercises/practice/affine-cipher/affine-cipher-tests.8th
+++ b/exercises/practice/affine-cipher/affine-cipher-tests.8th
@@ -47,4 +47,3 @@
 "decode with a not coprime to m"
 ( "Test" 13 5 code> )  test_null
 
-bye

--- a/exercises/practice/affine-cipher/test.8th
+++ b/exercises/practice/affine-cipher/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "affine-cipher.8th" dup . cr f:include
 "affine-cipher-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -8,8 +8,8 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"armstrong-numbers.8th" f:include`
-and you can run tests interactively by copying and pasting them in from armstrong-numbers-tests.8th or by entering your own. 
- 
+and you can run the tests with `"armstrong-numbers-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
+
 ### Editing the armstrong-numbers-tests.8th file
  
 This is encouraged at the beginning of your journey. Insert a back-slash space before all but the first one or two tests. Write your code to solve the first test or two. Then progressively enable more tests until you can pass all of them.

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f armstrong-numbers-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from armstrong-numbers-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"armstrong-numbers.8th" f:include`
+and you can run tests interactively by copying and pasting them in from armstrong-numbers-tests.8th or by entering your own. 
  
 ### Editing the armstrong-numbers-tests.8th file
  

--- a/exercises/practice/armstrong-numbers/armstrong-numbers-tests.8th
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers-tests.8th
@@ -10,4 +10,3 @@
 "Armstrong number containing seven zeroes" ( 186709961001538790100634132976990 armstrong? ) test_true
 "The largest and last Armstrong number" ( 115132219018763992565095597973971522401 armstrong? ) test_true
 
-bye

--- a/exercises/practice/armstrong-numbers/test.8th
+++ b/exercises/practice/armstrong-numbers/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "armstrong-numbers.8th" dup . cr f:include
 "armstrong-numbers-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/atbash-cipher/atbash-cipher-tests.8th
+++ b/exercises/practice/atbash-cipher/atbash-cipher-tests.8th
@@ -14,4 +14,3 @@
 "decode with too many spaces" ( "vc vix    r hn" atbash> ) "exercism" test_eqs
 "decode with no spaces" ( "zmlyhgzxovrhlugvmzhgvkkrmthglmv" atbash> ) "anobstacleisoftenasteppingstone" test_eqs
 
-bye

--- a/exercises/practice/atbash-cipher/test.8th
+++ b/exercises/practice/atbash-cipher/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "atbash-cipher.8th" dup . cr f:include
 "atbash-cipher-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"bob.8th" f:include`
-and you can run tests interactively by copying and pasting them in from bob-tests.8th or by entering your own. 
+and you can run the tests with `"bob-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the bob-tests.8th file
  

--- a/exercises/practice/bob/.docs/instructions.append.md
+++ b/exercises/practice/bob/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f bob-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from bob-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"bob.8th" f:include`
+and you can run tests interactively by copying and pasting them in from bob-tests.8th or by entering your own. 
  
 ### Editing the bob-tests.8th file
  

--- a/exercises/practice/bob/bob-tests.8th
+++ b/exercises/practice/bob/bob-tests.8th
@@ -16,4 +16,3 @@
 "asking a numeric question" ( "You are, what, like 15?" bob ) "Sure." test_eqs
 "shouting with special characters" ( "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!" bob ) "Whoa, chill out!" test_eqs
 
-bye

--- a/exercises/practice/bob/test.8th
+++ b/exercises/practice/bob/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "bob.8th" dup . cr f:include
 "bob-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/collatz-conjecture/.docs/instructions.append.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"collatz-conjecture.8th" f:include`
-and you can run tests interactively by copying and pasting them in from collatz-conjecture-tests.8th or by entering your own. 
+and you can run the tests with `"collatz-conjecture-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the collatz-conjecture-tests.8th file
  

--- a/exercises/practice/collatz-conjecture/.docs/instructions.append.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f collatz-conjecture-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from collatz-conjecture-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"collatz-conjecture.8th" f:include`
+and you can run tests interactively by copying and pasting them in from collatz-conjecture-tests.8th or by entering your own. 
  
 ### Editing the collatz-conjecture-tests.8th file
  

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-tests.8th
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-tests.8th
@@ -5,4 +5,3 @@
 "zero is an error" ( 0 collatz )  test_null
 "negative value is an error" ( -15 collatz ) test_null
 
-bye

--- a/exercises/practice/collatz-conjecture/test.8th
+++ b/exercises/practice/collatz-conjecture/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "collatz-conjecture.8th" dup . cr f:include
 "collatz-conjecture-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/darts/darts-tests.8th
+++ b/exercises/practice/darts/darts-tests.8th
@@ -12,4 +12,3 @@
 "Just outside the outer circle" 0 ( 7.1 -7.1 darts-score ) test_eq
 "Asymmetric position between the inner and middle circles" 5 ( 0.5 -4 darts-score ) test_eq
 
-bye

--- a/exercises/practice/darts/test.8th
+++ b/exercises/practice/darts/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "darts.8th" dup . cr f:include
 "darts-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"gigasecond.8th" f:include`
-and you can run tests interactively by copying and pasting them in from gigasecond-tests.8th or by entering your own. 
+and you can run the tests with `"gigasecond-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
 
 ### Editing the gigasecond-tests.8th file
  

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -6,10 +6,10 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f gigasecond-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from gigasecond-tests.8th or by entering your own. 
- 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"gigasecond.8th" f:include`
+and you can run tests interactively by copying and pasting them in from gigasecond-tests.8th or by entering your own. 
+
 ### Editing the gigasecond-tests.8th file
  
 This is encouraged at the beginning of your journey. Insert a back-slash space before all but the first one or two tests. Write your code to solve the first test or two. Then progressively enable more tests until you can pass all of them.

--- a/exercises/practice/gigasecond/gigasecond-tests.8th
+++ b/exercises/practice/gigasecond/gigasecond-tests.8th
@@ -3,4 +3,3 @@
 "third test for date only specification of time" ( [1959, 7, 19, 0, 0, 0, 0] d:join +gigasecond [1991, 3,27,1,46,40,0] d:join d:= ) test_true
 "full time specified" ( [2015, 1, 24, 22, 0, 0, 0] d:join +gigasecond [2046,10,2,23,46,40,0] d:join d:= ) test_true
 "full time with day roll-over" ( [2015, 1, 24, 23, 59, 59, 0] d:join +gigasecond [2046,10,3,1,46,39,0] d:join d:= ) test_true
-bye

--- a/exercises/practice/gigasecond/test.8th
+++ b/exercises/practice/gigasecond/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "gigasecond.8th" dup . cr f:include
 "gigasecond-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -5,10 +5,10 @@
 Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the PATH environment variable.
  
 ### From a REPL
- 
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f hamming-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from hamming-tests.8th or by entering your own. 
+
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"hamming.8th" f:include`
+and you can run tests interactively by copying and pasting them in from hamming-tests.8th or by entering your own. 
  
 ### Editing the hamming-tests.8th file
  

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
 
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"hamming.8th" f:include`
-and you can run tests interactively by copying and pasting them in from hamming-tests.8th or by entering your own. 
+and you can run the tests with `"hamming-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the hamming-tests.8th file
  

--- a/exercises/practice/hamming/hamming-tests.8th
+++ b/exercises/practice/hamming/hamming-tests.8th
@@ -8,4 +8,3 @@
 "disallow second strand longer"  ( "ATA" "AGTG" distance ) test_null
 "disallow empty second strand"  ( "G" "" distance ) test_null
 
-bye

--- a/exercises/practice/hamming/test.8th
+++ b/exercises/practice/hamming/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "hamming.8th" dup . cr f:include
 "hamming-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f hello-world-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from hello-world-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"hello-world.8th" f:include`
+and you can run tests interactively by copying and pasting them in from hello-world-tests.8th or by entering your own. 
  
 ### Editing the hello-world-tests.8th file
  

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"hello-world.8th" f:include`
-and you can run tests interactively by copying and pasting them in from hello-world-tests.8th or by entering your own. 
+and you can run the tests with `"hello-world-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the hello-world-tests.8th file
  

--- a/exercises/practice/hello-world/hello-world-tests.8th
+++ b/exercises/practice/hello-world/hello-world-tests.8th
@@ -1,2 +1,1 @@
 "hello world test" "Hello, World!" ( hello-world ) test_eqs
-bye

--- a/exercises/practice/hello-world/test.8th
+++ b/exercises/practice/hello-world/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "hello-world.8th" dup . cr f:include
 "hello-world-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f isogram-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from isogram-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"isogram.8th" f:include`
+and you can run tests interactively by copying and pasting them in from isogram-tests.8th or by entering your own. 
  
 ### Editing the isogram-tests.8th file
  

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"isogram.8th" f:include`
-and you can run tests interactively by copying and pasting them in from isogram-tests.8th or by entering your own. 
+and you can run the tests with `"isogram-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the isogram-tests.8th file
  

--- a/exercises/practice/isogram/isogram-tests.8th
+++ b/exercises/practice/isogram/isogram-tests.8th
@@ -13,4 +13,3 @@
 "same first and last characters" ( "angola" isogram? ) test_false
 "word with duplicated character and with two hyphens" ( "up-to-date" isogram? ) test_false
 
-bye

--- a/exercises/practice/isogram/test.8th
+++ b/exercises/practice/isogram/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "isogram.8th" dup . cr f:include
 "isogram-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"leap.8th" f:include`
-and you can run tests interactively by copying and pasting them in from leap-tests.8th or by entering your own. 
+and you can run the tests with `"leap-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the leap-tests.8th file
  

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f leap-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from leap-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"leap.8th" f:include`
+and you can run tests interactively by copying and pasting them in from leap-tests.8th or by entering your own. 
  
 ### Editing the leap-tests.8th file
  

--- a/exercises/practice/leap/leap-tests.8th
+++ b/exercises/practice/leap/leap-tests.8th
@@ -8,4 +8,3 @@
 "year divisible by 400 is leap year"  ( 2000 leap-year? ) test_true
 "year divisible by 400 but not by 125 is still a leap year"  ( 2400 leap-year? ) test_true
 
-bye

--- a/exercises/practice/leap/test.8th
+++ b/exercises/practice/leap/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "leap.8th" dup . cr f:include
 "leap-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/luhn/.docs/instructions.append.md
+++ b/exercises/practice/luhn/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
 
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"luhn.8th" f:include`
-and you can run tests interactively by copying and pasting them in from luhn-tests.8th or by entering your own. 
+and you can run the tests with `"luhn-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the luhn-tests.8th file
  

--- a/exercises/practice/luhn/.docs/instructions.append.md
+++ b/exercises/practice/luhn/.docs/instructions.append.md
@@ -5,10 +5,10 @@
 Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the PATH environment variable.
  
 ### From a REPL
- 
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f luhn-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from luhn-tests.8th or by entering your own. 
+
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"luhn.8th" f:include`
+and you can run tests interactively by copying and pasting them in from luhn-tests.8th or by entering your own. 
  
 ### Editing the luhn-tests.8th file
  

--- a/exercises/practice/luhn/luhn-tests.8th
+++ b/exercises/practice/luhn/luhn-tests.8th
@@ -64,4 +64,3 @@
 "non-numeric, non-space char in the middle with a sum that's divisible by 10 isn't allowed"
 ( "59%59" luhn ) test_false
 
-bye

--- a/exercises/practice/luhn/test.8th
+++ b/exercises/practice/luhn/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "luhn.8th" dup . cr f:include
 "luhn-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/pangram/.docs/instructions.append.md
+++ b/exercises/practice/pangram/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f pangram-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from pangram-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"pangram.8th" f:include`
+and you can run tests interactively by copying and pasting them in from pangram-tests.8th or by entering your own. 
  
 ### Editing the pangram-tests.8th file
  

--- a/exercises/practice/pangram/.docs/instructions.append.md
+++ b/exercises/practice/pangram/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"pangram.8th" f:include`
-and you can run tests interactively by copying and pasting them in from pangram-tests.8th or by entering your own. 
+and you can run the tests with `"pangram-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the pangram-tests.8th file
  

--- a/exercises/practice/pangram/pangram-tests.8th
+++ b/exercises/practice/pangram/pangram-tests.8th
@@ -9,4 +9,3 @@
 "missing d and g"  ( "the quick brown fox jumps over with lazy FX" pangram?  ) test_false
 "with underscores"  ( "the_quick_brown_fox_jumps_over_the_lazy_dog" pangram?  ) test_true
 
-bye

--- a/exercises/practice/pangram/test.8th
+++ b/exercises/practice/pangram/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "pangram.8th" dup . cr f:include
 "pangram-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f raindrops-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from raindrops-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"raindrops.8th" f:include`
+and you can run tests interactively by copying and pasting them in from raindrops-tests.8th or by entering your own. 
  
 ### Editing the raindrops-tests.8th file
  

--- a/exercises/practice/raindrops/.docs/instructions.append.md
+++ b/exercises/practice/raindrops/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"raindrops.8th" f:include`
-and you can run tests interactively by copying and pasting them in from raindrops-tests.8th or by entering your own. 
+and you can run the tests with `"raindrops-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the raindrops-tests.8th file
  

--- a/exercises/practice/raindrops/raindrops-tests.8th
+++ b/exercises/practice/raindrops/raindrops-tests.8th
@@ -17,4 +17,3 @@
 "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base" ( 8 raindrops ) "8" test_eqs
 "the sound of 9 is Pling as it has a factor 3" ( 9 raindrops ) "Pling" test_eqs
 
-bye

--- a/exercises/practice/raindrops/test.8th
+++ b/exercises/practice/raindrops/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "raindrops.8th" dup . cr f:include
 "raindrops-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/resistor-color/resistor-color-tests.8th
+++ b/exercises/practice/resistor-color/resistor-color-tests.8th
@@ -4,4 +4,3 @@
 
 "Colors" ( colors ) ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"] test_eqa
 
-bye

--- a/exercises/practice/resistor-color/test.8th
+++ b/exercises/practice/resistor-color/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "resistor-color.8th" dup . cr f:include
 "resistor-color-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -5,10 +5,10 @@
 Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the PATH environment variable.
  
 ### From a REPL
- 
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f reverse-string-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from reverse-string-tests.8th or by entering your own. 
+
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"reverse-string.8th" f:include`
+and you can run tests interactively by copying and pasting them in from reverse-string-tests.8th or by entering your own. 
  
 ### Editing the reverse-string-tests.8th file
  

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
 
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"reverse-string.8th" f:include`
-and you can run tests interactively by copying and pasting them in from reverse-string-tests.8th or by entering your own. 
+and you can run the tests with `"reverse-string-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the reverse-string-tests.8th file
  

--- a/exercises/practice/reverse-string/reverse-string-tests.8th
+++ b/exercises/practice/reverse-string/reverse-string-tests.8th
@@ -5,4 +5,3 @@
 "a palindrome" ( "racecar" reverse ) "racecar" test_eqs
 "an even-sized word" ( "drawer" reverse ) "reward" test_eqs
 
-bye

--- a/exercises/practice/reverse-string/test.8th
+++ b/exercises/practice/reverse-string/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "reverse-string.8th" dup . cr f:include
 "reverse-string-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"roman-numerals.8th" f:include`
-and you can run tests interactively by copying and pasting them in from roman-numerals-tests.8th or by entering your own. 
+and you can run the tests with `"roman-numerals-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the roman-numerals-tests.8th file
  

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f roman-numerals-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from roman-numerals-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"roman-numerals.8th" f:include`
+and you can run tests interactively by copying and pasting them in from roman-numerals-tests.8th or by entering your own. 
  
 ### Editing the roman-numerals-tests.8th file
  

--- a/exercises/practice/roman-numerals/roman-numerals-tests.8th
+++ b/exercises/practice/roman-numerals/roman-numerals-tests.8th
@@ -24,4 +24,3 @@
 "1666 is MDCLXVI" ( 1666 n:>roman ) "MDCLXVI" test_eqs
 "3001 is MMMI" ( 3001 n:>roman ) "MMMI" test_eqs
 "3999 is MMMCMXCIX" ( 3999 n:>roman ) "MMMCMXCIX" test_eqs
-bye

--- a/exercises/practice/roman-numerals/test.8th
+++ b/exercises/practice/roman-numerals/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "roman-numerals.8th" dup . cr f:include
 "roman-numerals-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/series/series-tests.8th
+++ b/exercises/practice/series/series-tests.8th
@@ -53,4 +53,3 @@
     [] 
     test_eqa
 
-bye

--- a/exercises/practice/series/test.8th
+++ b/exercises/practice/series/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "series.8th" dup . cr f:include
 "series-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"triangle.8th" f:include`
-and you can run tests interactively by copying and pasting them in from triangle-tests.8th or by entering your own. 
+and you can run the tests with `"triangle-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the triangle-tests.8th file
  

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f triangle-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from triangle-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"triangle.8th" f:include`
+and you can run tests interactively by copying and pasting them in from triangle-tests.8th or by entering your own. 
  
 ### Editing the triangle-tests.8th file
  

--- a/exercises/practice/triangle/test.8th
+++ b/exercises/practice/triangle/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "triangle.8th" dup . cr f:include
 "triangle-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/triangle/triangle-tests.8th
+++ b/exercises/practice/triangle/triangle-tests.8th
@@ -21,4 +21,3 @@
 "broken triangle #1" ( 0 3 3 scalene? ) test_false
 "broken triangle #2" ( 0 3 0 scalene? ) test_false
 
-bye

--- a/exercises/practice/trinary/.docs/instructions.append.md
+++ b/exercises/practice/trinary/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"trinary.8th" f:include`
-and you can run tests interactively by copying and pasting them in from trinary-tests.8th or by entering your own. 
+and you can run the tests with `"trinary-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the trinary-tests.8th file
  

--- a/exercises/practice/trinary/.docs/instructions.append.md
+++ b/exercises/practice/trinary/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f trinary-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from trinary-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"trinary.8th" f:include`
+and you can run tests interactively by copying and pasting them in from trinary-tests.8th or by entering your own. 
  
 ### Editing the trinary-tests.8th file
  

--- a/exercises/practice/trinary/test.8th
+++ b/exercises/practice/trinary/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "trinary.8th" dup . cr f:include
 "trinary-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/trinary/trinary-tests.8th
+++ b/exercises/practice/trinary/trinary-tests.8th
@@ -9,4 +9,3 @@
 "invalid trinary is decimal 0" ( "carrot" trinary> ) 0  test_eq
 "digits from 3 to 9 are invalid" ( "123" trinary> ) 0  test_eq
 
-bye

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f two-fer-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from two-fer-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"two-fer.8th" f:include`
+and you can run tests interactively by copying and pasting them in from two-fer-tests.8th or by entering your own. 
  
 ### Editing the two-fer-tests.8th file
  

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"two-fer.8th" f:include`
-and you can run tests interactively by copying and pasting them in from two-fer-tests.8th or by entering your own. 
+and you can run the tests with `"two-fer-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the two-fer-tests.8th file
  

--- a/exercises/practice/two-fer/test.8th
+++ b/exercises/practice/two-fer/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "two-fer.8th" dup . cr f:include
 "two-fer-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/two-fer/two-fer-tests.8th
+++ b/exercises/practice/two-fer/two-fer-tests.8th
@@ -2,4 +2,3 @@
 "Unnamed person test with null" ( null two-fer ) "One for you, one for me." test_eqs
 "One for the judge" ( "Jedoon" two-fer ) "One for Jedoon, one for me." test_eqs
 "One for the Hebrew shade-facing one" ( "הַצְּלֶלְפּוֹנִי" two-fer ) "One for הַצְּלֶלְפּוֹנִי, one for me." test_eqs
-bye

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"word-count.8th" f:include`
-and you can run tests interactively by copying and pasting them in from word-count-tests.8th or by entering your own. 
+and you can run the tests with `"word-count-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the word-count-tests.8th file
  

--- a/exercises/practice/word-count/.docs/instructions.append.md
+++ b/exercises/practice/word-count/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f word-count-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from word-count-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"word-count.8th" f:include`
+and you can run tests interactively by copying and pasting them in from word-count-tests.8th or by entering your own. 
  
 ### Editing the word-count-tests.8th file
  

--- a/exercises/practice/word-count/test.8th
+++ b/exercises/practice/word-count/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "word-count.8th" dup . cr f:include
 "word-count-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/word-count/word-count-tests.8th
+++ b/exercises/practice/word-count/word-count-tests.8th
@@ -13,4 +13,3 @@
 "alternating word separators not detected as a word"   ( ",\n,one,\n ,two \n 'three'" word-count ) { "one":1,"two":1,"three":1 } test_map_eq
 "quotation for word with apostrophe"   ( "can, can't, 'can't'" word-count ) { "can":1,"can't":2 } test_map_eq
 
-bye

--- a/exercises/practice/yacht/.docs/instructions.append.md
+++ b/exercises/practice/yacht/.docs/instructions.append.md
@@ -8,7 +8,7 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 Start 8th loading test-words.8th: `8th -f test-words.8th`.
 This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"yacht.8th" f:include`
-and you can run tests interactively by copying and pasting them in from yacht-tests.8th or by entering your own. 
+and you can run the tests with `"yacht-tests.8th" f:include` or you can copy and paste a single test from that file or enter your own. 
  
 ### Editing the yacht-tests.8th file
  

--- a/exercises/practice/yacht/.docs/instructions.append.md
+++ b/exercises/practice/yacht/.docs/instructions.append.md
@@ -6,9 +6,9 @@ Simply type `8th test.8th`. It is assumed that the 8th binary is declared in the
  
 ### From a REPL
  
-Start 8th loading test-words.8th and your solution file:
-`8th -f test-words.8th -f yacht-tests.8th`
-This will start a CLI session where you can run tests interactively by copying and pasting them in from yacht-tests.8th or by entering your own. 
+Start 8th loading test-words.8th: `8th -f test-words.8th`.
+This will start a CLI session where, once you’ve written some code in your solution file, you can load it with `"yacht.8th" f:include`
+and you can run tests interactively by copying and pasting them in from yacht-tests.8th or by entering your own. 
  
 ### Editing the yacht-tests.8th file
  

--- a/exercises/practice/yacht/test.8th
+++ b/exercises/practice/yacht/test.8th
@@ -1,3 +1,4 @@
 "test-words.8th" dup . cr f:include
 "yacht.8th" dup . cr f:include
 "yacht-tests.8th" dup . cr f:include
+bye

--- a/exercises/practice/yacht/yacht-tests.8th
+++ b/exercises/practice/yacht/yacht-tests.8th
@@ -28,4 +28,3 @@
 "Choice" 23 ( [3, 3, 5, 6, 6] "choice"  play_yacht ) test_eq
 "Yacht as choice" 10 ( [2, 2, 2, 2, 2] "choice"  play_yacht ) test_eq
 
-bye


### PR DESCRIPTION
Documentation change to resolve #90.

In that issue, axtens suggests that the instructions discuss using `f:include` to read in the tests file as well as the solution file. I haven’t done that here as the tests file include the `bye` word which closes the REPL for the student and that may not be what they would want.