### PR TITLE
The test_null word leaves null on the stack

### DIFF
--- a/exercises/practice/acronym/test-words.8th
+++ b/exercises/practice/acronym/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/affine-cipher/test-words.8th
+++ b/exercises/practice/affine-cipher/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/armstrong-numbers/test-words.8th
+++ b/exercises/practice/armstrong-numbers/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/atbash-cipher/test-words.8th
+++ b/exercises/practice/atbash-cipher/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/bob/test-words.8th
+++ b/exercises/practice/bob/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/collatz-conjecture/test-words.8th
+++ b/exercises/practice/collatz-conjecture/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/darts/test-words.8th
+++ b/exercises/practice/darts/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/gigasecond/test-words.8th
+++ b/exercises/practice/gigasecond/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/hamming/test-words.8th
+++ b/exercises/practice/hamming/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/hello-world/test-words.8th
+++ b/exercises/practice/hello-world/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/isogram/test-words.8th
+++ b/exercises/practice/isogram/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/leap/test-words.8th
+++ b/exercises/practice/leap/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/luhn/test-words.8th
+++ b/exercises/practice/luhn/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/pangram/test-words.8th
+++ b/exercises/practice/pangram/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/raindrops/test-words.8th
+++ b/exercises/practice/raindrops/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/resistor-color/test-words.8th
+++ b/exercises/practice/resistor-color/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/reverse-string/test-words.8th
+++ b/exercises/practice/reverse-string/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/roman-numerals/test-words.8th
+++ b/exercises/practice/roman-numerals/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/series/test-words.8th
+++ b/exercises/practice/series/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/triangle/test-words.8th
+++ b/exercises/practice/triangle/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/trinary/test-words.8th
+++ b/exercises/practice/trinary/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/two-fer/test-words.8th
+++ b/exercises/practice/two-fer/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/word-count/test-words.8th
+++ b/exercises/practice/word-count/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 

--- a/exercises/practice/yacht/test-words.8th
+++ b/exercises/practice/yacht/test-words.8th
@@ -49,7 +49,7 @@ var tests-failed
 
 : test_null \ s w --
    w:exec
-   null?
+   null? nip
    if test-passed else test-failed then 
 ;
 


### PR DESCRIPTION
This obscures the test names:
```sh
$ 8th test.8th
test-words.8th
collatz-conjecture.8th
collatz-conjecture-tests.8th
zero steps for one  ... OK
large number of even and odd steps  ... OK
even and odd steps  ... OK
divide if even  ... OK
null  ... OK
null  ... OK
6 tests planned - 6 passed - 0 failed
```

With this fix:
```sh
...
divide if even  ... OK
zero is an error  ... OK
negative value is an error  ... OK
6 tests planned - 6 passed - 0 failed
```