### PR TITLE
gigasecond: Fix failing tests

### DIFF
--- a/exercises/practice/gigasecond/gigasecond-tests.8th
+++ b/exercises/practice/gigasecond/gigasecond-tests.8th
@@ -1,8 +1,12 @@
 5 tests
-"date only specification of time" ( [2011, 4, 25, 0, 0, 0, 0] d:join +gigasecond [2043,1, 1,1,46,40,0] d:join d:= ) test_true
-"second test for date only specification of time" ( [1977, 6, 13, 0, 0, 0, 0] d:join +gigasecond [2009, 2,19,1,46,40,0] d:join d:= ) test_true
-"third test for date only specification of time" ( [1959, 7, 19, 0, 0, 0, 0] d:join +gigasecond [1991, 3,27,1,46,40,0] d:join d:= ) test_true
-"full time specified" ( [2015, 1, 24, 22, 0, 0, 0] d:join +gigasecond [2046,10,2,23,46,40,0] d:join d:= ) test_true
-"full time with day roll-over" ( [2015, 1, 24, 23, 59, 59, 0] d:join +gigasecond [2046,10,3,1,46,39,0] d:join d:= ) test_true
+
+\ Workaround for https://8th-dev.com/bin/bugs/tktview/624833cc8d
+0 d:updatetz
+
+"date only specification of time" ( [2011, 4, 25, 0, 0, 0, 0, 0, 0, 0] d:join +gigasecond [2043,1, 1,1,46,40,0, 0, 0, 0] d:join d:= ) test_true
+"second test for date only specification of time" ( [1977, 6, 13, 0, 0, 0, 0, 0, 0, 0] d:join +gigasecond [2009, 2,19,1,46,40,0, 0, 0, 0] d:join d:= ) test_true
+"third test for date only specification of time" ( [1959, 7, 19, 0, 0, 0, 0, 0, 0, 0] d:join +gigasecond [1991, 3,27,1,46,40,0, 0, 0, 0] d:join d:= ) test_true
+"full time specified" ( [2015, 1, 24, 22, 0, 0, 0, 0, 0, 0] d:join +gigasecond [2046,10,2,23,46,40,0, 0, 0, 0] d:join d:= ) test_true
+"full time with day roll-over" ( [2015, 1, 24, 23, 59, 59, 0, 0, 0, 0] d:join +gigasecond [2046,10,3,1,46,39,0, 0, 0, 0] d:join d:= ) test_true
 
 end-of-tests


### PR DESCRIPTION
There are two causes of failures. First, if the two dates are joined at different milliseconds, then they will inherit different millisecond values during d:join, unless the full 10 items are specified in the array.

Second, there is a bug with d:+msec in 8th version 23.06 (I believe since in 23.02 https://8th-dev.com/bin/bugs/tktview/b82069cc12), causing the time to change by the value of the local time zone. If your time zone GMT you won't notice. It is fixed for the next release (23.07?). https://8th-dev.com/bin/bugs/tktview/624833cc8d