### PR TITLE
test-words: fix test_eqa2 to skip tests, normalize test-words.8th

### DIFF
--- a/exercises/practice/acronym/test-words.8th
+++ b/exercises/practice/acronym/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/affine-cipher/test-words.8th
+++ b/exercises/practice/affine-cipher/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/armstrong-numbers/test-words.8th
+++ b/exercises/practice/armstrong-numbers/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/atbash-cipher/test-words.8th
+++ b/exercises/practice/atbash-cipher/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/bob/test-words.8th
+++ b/exercises/practice/bob/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/collatz-conjecture/test-words.8th
+++ b/exercises/practice/collatz-conjecture/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/darts/test-words.8th
+++ b/exercises/practice/darts/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/gigasecond/test-words.8th
+++ b/exercises/practice/gigasecond/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/hamming/test-words.8th
+++ b/exercises/practice/hamming/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/hello-world/test-words.8th
+++ b/exercises/practice/hello-world/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/isogram/test-words.8th
+++ b/exercises/practice/isogram/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/leap/test-words.8th
+++ b/exercises/practice/leap/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/luhn/test-words.8th
+++ b/exercises/practice/luhn/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/pangram/test-words.8th
+++ b/exercises/practice/pangram/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/pythagorean-triplet/test-words.8th
+++ b/exercises/practice/pythagorean-triplet/test-words.8th
@@ -86,26 +86,27 @@ true var, run-test
 \ Note: This may be used in some test files. For example, to compare results
 \ that are not required to be in a certain order.
 : a:cmp SED: a1 a2 w -- n
-  >r
-  over a:len nip over a:len nip n:cmp
-  true mark -rot \ Stack: length-cmp a1 a2
-  ( r@ w:exec nip dup if break else drop then ) a:2each
-  rdrop \ Done with comparison word
-  2drop \ Done with a1 and a2
-  mark?
-  !if \ Got a non-zero result from a compare
-    nip
-  then
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
 ;
 
 \ Test that array a is equal to the result of word w. Compare arrays by
 \ testing elements with array equality. The SED of w is -- a1, where a1
 \ is an array of arrays. The elements of each sub-array must be numbers.
 : test_eqa2 SED: s a w --
-  isword? !if swap then
-  w:exec
-  ( ' n:= a:= nip nip ) a:= nip nip
-  if test-passed else test-failed then 
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
 ;
 
 : test_map_eq \ s m w -- | s w m -- 

--- a/exercises/practice/raindrops/test-words.8th
+++ b/exercises/practice/raindrops/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/resistor-color/test-words.8th
+++ b/exercises/practice/resistor-color/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/reverse-string/test-words.8th
+++ b/exercises/practice/reverse-string/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/roman-numerals/test-words.8th
+++ b/exercises/practice/roman-numerals/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/series/test-words.8th
+++ b/exercises/practice/series/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/triangle/test-words.8th
+++ b/exercises/practice/triangle/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/trinary/test-words.8th
+++ b/exercises/practice/trinary/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/two-fer/test-words.8th
+++ b/exercises/practice/two-fer/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/word-count/test-words.8th
+++ b/exercises/practice/word-count/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/exercises/practice/yacht/test-words.8th
+++ b/exercises/practice/yacht/test-words.8th
@@ -79,6 +79,36 @@ true var, run-test
    if test-passed else test-failed then 
 ;
 
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
 : test_map_eq \ s m w -- | s w m -- 
    run-test? !if 2drop test-skipped ;; then
    isword? !if swap then

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,20 @@
+# Common files
+
+Every exercise needs a separate copy of the test-words.8th file.
+This is due to the way exercises are delivered to students.
+
+Let's keep this directory as the "master" version of the file,
+and we can deploy it to exercises with:
+
+```sh
+for ex in ./exercises/practice/*; do
+    cp -v ./lib/test-words.8th "$ex"
+done
+```
+
+To verify that all copies are in sync (should produce no output):
+```sh
+for ex in ./exercises/*/*/test-words.8th; do
+    cmp "$ex" ./lib/test-words.8th
+done
+```

--- a/lib/test-words.8th
+++ b/lib/test-words.8th
@@ -1,0 +1,158 @@
+needs console/loaded
+
+-1 var, test-count
+var tests-passed
+var tests-failed
+var tests-skipped
+
+true var, run-test
+: SKIP-REST-OF-TESTS false run-test ! ;
+
+: tests \ n -- 
+    test-count ! 
+;
+
+: test-passed \ s --
+    1 tests-passed n:+!
+    con:green con:onBlack . space " ... OK" . con:white con:onBlack cr
+;
+
+: test-skipped \ s --
+    1 tests-skipped n:+!
+    con:cyan con:onBlack . space " ... SKIPPED" . con:white con:onBlack cr
+;
+
+: test-failed \ s --
+    1 tests-failed n:+!
+    con:red con:onBlack . space " ... FAIL" . con:white con:onBlack cr
+;
+
+: isword?  \ x -- x f
+   dup  >kind  ns:w   n:= 
+;
+
+: run-test? \ -- T
+   run-test @ if true else "RUN_ALL_TESTS" getenv n:>bool then
+;
+
+: test_eq \ s x w -- | s w x --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   n:=
+   if test-passed else test-failed then 
+;
+
+: test_eqs \ s x w -- | s w x -- 
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   s:=
+   if test-passed else test-failed then 
+;
+
+: test_true \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   if test-passed else test-failed then 
+;
+
+: test_false \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   if test-failed else test-passed then 
+;
+
+: test_null \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   null? nip
+   if test-passed else test-failed then 
+;
+
+\ compare arrays by testing elements with string equality
+: test_eqa \ s x w -- | s w x -- 
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ' s:= a:= 2nip
+   if test-passed else test-failed then 
+;
+
+\ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
+\ The result n is:
+\ - The first non-zero result of ( a1[i] a2[i] w ), or
+\ - n:cmp of the lengths of a1 and a2
+\ Note: This may be used in some test files. For example, to compare results
+\ that are not required to be in a certain order.
+: a:cmp SED: a1 a2 w -- n
+   >r
+   over a:len nip over a:len nip n:cmp
+   true mark -rot \ Stack: length-cmp a1 a2
+   ( r@ w:exec nip dup if break else drop then ) a:2each
+   rdrop \ Done with comparison word
+   2drop \ Done with a1 and a2
+   mark?
+   !if \ Got a non-zero result from a compare
+      nip
+   then
+;
+
+\ Test that array a is equal to the result of word w. Compare arrays by
+\ testing elements with array equality. The SED of w is -- a1, where a1
+\ is an array of arrays. The elements of each sub-array must be numbers.
+: test_eqa2 SED: s a w --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ( ' n:= a:= nip nip ) a:= nip nip
+   if test-passed else test-failed then 
+;
+
+: test_map_eq \ s m w -- | s w m -- 
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ' n:= m:= 2nip
+   if test-passed else test-failed then 
+;
+
+: test_map_neq \ s m w -- | s w m -- 
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   ' n:= m:= 2nip
+   if test-failed else test-passed then 
+;
+
+\ Num passed + num skipped + num failed should == num tests
+: all-tests-run? \ -- T
+    tests-passed @ tests-skipped @ tests-failed @ n:+ n:+
+    test-count @ n:=
+;
+
+( all-tests-run?  
+  !if con:red con:onBlack "... FAIL - not all tests completed" . con:white con:onBlack cr then
+) onexit
+
+\ Print a summary of the tests run
+( con:white con:onBlack
+  test-count   @ . space "tests planned - " .
+  tests-passed @ . space "passed - " .
+  tests-skipped @ . space "skipped - " .
+  tests-failed @ . space "failed" . cr
+) onexit
+
+\ Set the exit status:
+\   0 = all OK
+\   1 = not all tests were run (some error occurred)
+\   2 = some tests failed
+: end-of-tests \ --
+    all-tests-run?
+    if
+      tests-failed @ 0 n:= if 0 else 2 then
+    else
+      1
+    then
+    die
+;


### PR DESCRIPTION
1) All test-words.8th should be identical to avoid maintenance
   headaches. The pythagorean-triplet/test-words.8th was not in sync
   with the rest.

2) The new test_eqa2 word was missing the run-test? check; so it ignored
   SKIP-REST-OF-TESTS.