### PR TITLE
with: test / ;with in all test.8th

### DIFF
--- a/bin/add-exercise
+++ b/bin/add-exercise
@@ -63,12 +63,13 @@ cp ./libs/exercism/test "exercises/practice/${slug}/libs/exercism/test"
 cat << END_TEST > "exercises/practice/${slug}/test.8th"
 "${slug}.8th" f:include
 needs exercism/test
-
+with: test
 N tests
 
 $(curl --silent "https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises/${slug}/canonical-data.json")
 
 end-of-tests
+;with
 END_TEST
 
 touch "exercises/practice/${slug}/${slug}.8th"

--- a/exercises/practice/acronym/acronym.8th
+++ b/exercises/practice/acronym/acronym.8th
@@ -1,3 +1,3 @@
 : acronym \ s -- s
-  /[^a-zA-Z']/ s:/ ( 0 1 s:slice s:uc ) a:map "" a:join
+  
 ;

--- a/exercises/practice/acronym/acronym.8th
+++ b/exercises/practice/acronym/acronym.8th
@@ -1,3 +1,3 @@
 : acronym \ s -- s
-
+  /[^a-zA-Z']/ s:/ ( 0 1 s:slice s:uc ) a:map "" a:join
 ;

--- a/exercises/practice/acronym/libs/exercism/test
+++ b/exercises/practice/acronym/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/acronym/test.8th
+++ b/exercises/practice/acronym/test.8th
@@ -1,5 +1,6 @@
 "acronym.8th" f:include
 needs exercism/test
+with:test
 
 9 tests
 
@@ -51,3 +52,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/affine-cipher/libs/exercism/test
+++ b/exercises/practice/affine-cipher/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/affine-cipher/test.8th
+++ b/exercises/practice/affine-cipher/test.8th
@@ -1,5 +1,6 @@
 "affine-cipher.8th" f:include
 needs exercism/test
+with: test
 
 16 tests
 
@@ -84,3 +85,4 @@ SKIP-REST-OF-TESTS
     null?
 
 end-of-tests
+;with

--- a/exercises/practice/armstrong-numbers/libs/exercism/test
+++ b/exercises/practice/armstrong-numbers/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/armstrong-numbers/test.8th
+++ b/exercises/practice/armstrong-numbers/test.8th
@@ -1,6 +1,6 @@
 "armstrong-numbers.8th" f:include
 needs exercism/test
-
+with: test
 11 tests
 
 "Zero is an Armstrong number"    ( 0 armstrong?  ) true?
@@ -17,3 +17,4 @@ SKIP-REST-OF-TESTS
 "The largest and last Armstrong number" ( 115132219018763992565095597973971522401 armstrong? ) true?
 
 end-of-tests
+;with

--- a/exercises/practice/atbash-cipher/libs/exercism/test
+++ b/exercises/practice/atbash-cipher/libs/exercism/test
@@ -134,4 +134,4 @@ true var, run-test
     die
 ;
 
-with: test
+

--- a/exercises/practice/atbash-cipher/test.8th
+++ b/exercises/practice/atbash-cipher/test.8th
@@ -1,6 +1,6 @@
 "atbash-cipher.8th" f:include
 needs exercism/test
-
+with: test
 14 tests
 
 "encode yes"
@@ -63,3 +63,4 @@ SKIP-REST-OF-TESTS
   equal?
 
 end-of-tests
+;with

--- a/exercises/practice/bob/libs/exercism/test
+++ b/exercises/practice/bob/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/bob/test.8th
+++ b/exercises/practice/bob/test.8th
@@ -1,6 +1,6 @@
 "bob.8th" f:include
 needs exercism/test
-
+with: test
 17 tests
 
 "prolonged silence"
@@ -91,3 +91,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/collatz-conjecture/libs/exercism/test
+++ b/exercises/practice/collatz-conjecture/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/collatz-conjecture/test.8th
+++ b/exercises/practice/collatz-conjecture/test.8th
@@ -1,6 +1,6 @@
 "collatz-conjecture.8th" f:include
 needs exercism/test
-
+with: test
 6 tests
 
 "zero steps for one"
@@ -34,3 +34,4 @@ SKIP-REST-OF-TESTS
     null?
 
 end-of-tests
+;with

--- a/exercises/practice/darts/libs/exercism/test
+++ b/exercises/practice/darts/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/darts/test.8th
+++ b/exercises/practice/darts/test.8th
@@ -1,6 +1,6 @@
 "darts.8th" f:include
 needs exercism/test
-
+with: test
 13 tests
 
 "Missed target"
@@ -71,3 +71,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/eliuds-eggs/libs/exercism/test
+++ b/exercises/practice/eliuds-eggs/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/eliuds-eggs/test.8th
+++ b/exercises/practice/eliuds-eggs/test.8th
@@ -1,6 +1,6 @@
 "pop-count.8th" f:include
 needs exercism/test
-
+with: test
 4 tests
 
 "0 eggs"
@@ -26,3 +26,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/etl/libs/exercism/test
+++ b/exercises/practice/etl/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/etl/test.8th
+++ b/exercises/practice/etl/test.8th
@@ -1,6 +1,6 @@
 "etl.8th" f:include
 needs exercism/test
-
+with: test
 4 tests
 
 "single letter"
@@ -60,3 +60,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/gigasecond/libs/exercism/test
+++ b/exercises/practice/gigasecond/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/gigasecond/test.8th
+++ b/exercises/practice/gigasecond/test.8th
@@ -1,6 +1,6 @@
 "gigasecond.8th" f:include
 needs exercism/test
-
+with: test
 5 tests
 
 \ Workaround for https://8th-dev.com/bin/bugs/tktview/624833cc8d
@@ -34,3 +34,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/hamming/libs/exercism/test
+++ b/exercises/practice/hamming/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/hamming/test.8th
+++ b/exercises/practice/hamming/test.8th
@@ -1,6 +1,6 @@
 "hamming.8th" f:include
 needs exercism/test
-
+with: test
 9 tests
 
 "empty strands"
@@ -46,3 +46,4 @@ SKIP-REST-OF-TESTS
     null?
 
 end-of-tests
+;with

--- a/exercises/practice/hello-world/libs/exercism/test
+++ b/exercises/practice/hello-world/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/hello-world/test.8th
+++ b/exercises/practice/hello-world/test.8th
@@ -1,8 +1,9 @@
 "hello-world.8th" f:include
 needs exercism/test
-
+with: test
 1 tests
 
 "hello world test" "Hello, World!" ( hello-world ) equal?
 
 end-of-tests
+;with

--- a/exercises/practice/isogram/libs/exercism/test
+++ b/exercises/practice/isogram/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/isogram/test.8th
+++ b/exercises/practice/isogram/test.8th
@@ -1,6 +1,6 @@
 "isogram.8th" f:include
 needs exercism/test
-
+with: test
 14 tests
 
 "empty string" ( "" isogram? ) true?
@@ -20,3 +20,4 @@ SKIP-REST-OF-TESTS
 "word with duplicated character and with two hyphens" ( "up-to-date" isogram? ) false?
 
 end-of-tests
+;with

--- a/exercises/practice/leap/libs/exercism/test
+++ b/exercises/practice/leap/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/leap/test.8th
+++ b/exercises/practice/leap/test.8th
@@ -1,6 +1,6 @@
 "leap.8th" f:include
 needs exercism/test
-
+with: test
 9 tests
 
 "year not divisible by 4 in common year"  ( 2015 leap-year? ) false?
@@ -15,3 +15,4 @@ SKIP-REST-OF-TESTS
 "year divisible by 400 but not by 125 is still a leap year"   ( 2400 leap-year? )  true?
 
 end-of-tests
+;with

--- a/exercises/practice/luhn/libs/exercism/test
+++ b/exercises/practice/luhn/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/luhn/test.8th
+++ b/exercises/practice/luhn/test.8th
@@ -1,6 +1,6 @@
 "luhn.8th" f:include
 needs exercism/test
-
+with: test
 22 tests
 
 "single digit strings can not be valid"
@@ -94,3 +94,4 @@ SKIP-REST-OF-TESTS
     false?
 
 end-of-tests
+;with

--- a/exercises/practice/pangram/libs/exercism/test
+++ b/exercises/practice/pangram/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/pangram/test.8th
+++ b/exercises/practice/pangram/test.8th
@@ -1,6 +1,6 @@
 "pangram.8th" f:include
 needs exercism/test
-
+with: test
 10 tests
 
 "empty sentence"
@@ -46,3 +46,4 @@ SKIP-REST-OF-TESTS
     true?
 
 end-of-tests
+;with

--- a/exercises/practice/pythagorean-triplet/libs/exercism/test
+++ b/exercises/practice/pythagorean-triplet/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/pythagorean-triplet/test.8th
+++ b/exercises/practice/pythagorean-triplet/test.8th
@@ -1,6 +1,6 @@
 "pythagorean-triplet.8th" f:include
 needs exercism/test
-
+with: test
 7 tests
 
 \ Compare a1 to a2. Individual elements are compared with w (e.g., n:cmp).
@@ -66,3 +66,4 @@ SKIP-REST-OF-TESTS
 \     1_000_000  test-triplets-with-sum
 
 end-of-tests
+;with

--- a/exercises/practice/raindrops/libs/exercism/test
+++ b/exercises/practice/raindrops/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/raindrops/test.8th
+++ b/exercises/practice/raindrops/test.8th
@@ -1,6 +1,6 @@
 "raindrops.8th" f:include
 needs exercism/test
-
+with: test
 18 tests
 
 "the sound of 1 is 1"
@@ -96,3 +96,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/resistor-color/libs/exercism/test
+++ b/exercises/practice/resistor-color/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/resistor-color/test.8th
+++ b/exercises/practice/resistor-color/test.8th
@@ -1,6 +1,6 @@
 "resistor-color.8th" f:include
 needs exercism/test
-
+with: test
 4 tests 
 
 "Black"  ( "black" color-code )  0 equal?
@@ -11,3 +11,4 @@ SKIP-REST-OF-TESTS
 "Colors" ( colors ) ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"] equal?
 
 end-of-tests
+;with

--- a/exercises/practice/reverse-string/libs/exercism/test
+++ b/exercises/practice/reverse-string/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/reverse-string/test.8th
+++ b/exercises/practice/reverse-string/test.8th
@@ -1,6 +1,6 @@
 "reverse-string.8th" f:include
 needs exercism/test
-
+with: test
 6 tests
 
 "an empty string"
@@ -36,3 +36,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/roman-numerals/libs/exercism/test
+++ b/exercises/practice/roman-numerals/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/roman-numerals/test.8th
+++ b/exercises/practice/roman-numerals/test.8th
@@ -1,6 +1,6 @@
 "roman-numerals.8th" f:include
 needs exercism/test
-
+with: test
 26 tests
 
 "1 is I"
@@ -136,3 +136,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/series/libs/exercism/test
+++ b/exercises/practice/series/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/series/test.8th
+++ b/exercises/practice/series/test.8th
@@ -1,6 +1,6 @@
 "series.8th" f:include
 needs exercism/test
-
+with: test
 11 tests
 
 "slices of one from one" 
@@ -61,3 +61,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/sieve/libs/exercism/test
+++ b/exercises/practice/sieve/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/sieve/test.8th
+++ b/exercises/practice/sieve/test.8th
@@ -1,6 +1,6 @@
 "sieve.8th" f:include
 needs exercism/test
-
+with: test
 5 tests
 
 "no primes under two"
@@ -41,3 +41,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/triangle/libs/exercism/test
+++ b/exercises/practice/triangle/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/triangle/test.8th
+++ b/exercises/practice/triangle/test.8th
@@ -1,6 +1,6 @@
 "triangle.8th" f:include
 needs exercism/test
-
+with: test
 21 tests
 
 "invalid: 0 0 0" ( 0 0 0 equilateral? ) false?
@@ -29,3 +29,4 @@ SKIP-REST-OF-TESTS
 "broken triangle #2"                 ( 0 3 0 scalene? ) false?
 
 end-of-tests
+;with

--- a/exercises/practice/trinary/libs/exercism/test
+++ b/exercises/practice/trinary/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/trinary/test.8th
+++ b/exercises/practice/trinary/test.8th
@@ -1,6 +1,6 @@
 "trinary.8th" f:include
 needs exercism/test
-
+with: test
 10 tests
 
 "1 is decimal 1"
@@ -56,3 +56,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/two-fer/libs/exercism/test
+++ b/exercises/practice/two-fer/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/two-fer/test.8th
+++ b/exercises/practice/two-fer/test.8th
@@ -1,6 +1,6 @@
 "two-fer.8th" f:include
 needs exercism/test
-
+with: test
 4 tests 
 
 "Unnamed person test with empty string"
@@ -26,3 +26,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/word-count/libs/exercism/test
+++ b/exercises/practice/word-count/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/word-count/test.8th
+++ b/exercises/practice/word-count/test.8th
@@ -1,6 +1,6 @@
 "word-count.8th" f:include
 needs exercism/test
-
+with: test
 14 tests
 
 "count one word"
@@ -76,3 +76,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/exercises/practice/yacht/libs/exercism/test
+++ b/exercises/practice/yacht/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/exercises/practice/yacht/test.8th
+++ b/exercises/practice/yacht/test.8th
@@ -1,6 +1,6 @@
 "yacht.8th" f:include
 needs exercism/test
-
+with: test
 29 tests 
 
 "Yacht"
@@ -151,3 +151,4 @@ SKIP-REST-OF-TESTS
     equal?
 
 end-of-tests
+;with

--- a/libs/exercism/test
+++ b/libs/exercism/test
@@ -134,4 +134,3 @@ true var, run-test
     die
 ;
 
-with: test

--- a/test-failure-demo.8th
+++ b/test-failure-demo.8th
@@ -1,5 +1,5 @@
 needs exercism/test
-
+with: test
 \ A "test" file that contains several expected failures.
 \ The purpose is to see what the actual/expected output looks like.
 
@@ -56,3 +56,4 @@ needs exercism/test
 \ 32
 
 end-of-tests
+;with


### PR DESCRIPTION
CLI-based testing issue reported in https://forum.exercism.org/t/having-trouble-with-8th/10069 

Will take this up with Ron Aaron, that a `with: test` at the end of the `./libs/exercism/test` doesn't appear to work when the file is `needs` included and that the `with: test` is required again in the `test.8th` file itself.

In `hello-world`, the `with: test` at the end of `./libs/exercise/test` appears to be being ignored. Putting `with: test` after the `needs` in `hello-world`'s `test.8th`  makes the `test` namespace visible to the tests in `test.8th`

__LATER__
According to [this conversation](https://8th-dev.com/forum/index.php?topic=2814.0) there's no point in putting `with: test` at the bottom of `./libs/exercism/test`, so I've removed them.