### PR TITLE
Fix test workflow not working on PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
   workflow_dispatch:
 


### PR DESCRIPTION
@axtens This PR should fix the problem we had that the test workflow did not run properly when a PR was created from a fork.