### PR TITLE
Add `knapsack` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -524,6 +524,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3
+      },
+      {
+        "slug": "knapsack",
+        "name": "Knapsack",
+        "uuid": "3123e9f2-0d91-4ddc-b67c-ad9340af859e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 5
       }
     ]
   },

--- a/exercises/practice/knapsack/.docs/instructions.md
+++ b/exercises/practice/knapsack/.docs/instructions.md
@@ -1,0 +1,35 @@
+# Instructions
+
+In this exercise, let's try to solve a classic problem.
+
+Bob is a thief.
+After months of careful planning, he finally manages to crack the security systems of a high-class apartment.
+
+In front of him are many items, each with a value (v) and weight (w).
+Bob, of course, wants to maximize the total value he can get; he would gladly take all of the items if he could.
+However, to his horror, he realizes that the knapsack he carries with him can only hold so much weight (W).
+
+Given a knapsack with a specific carrying capacity (W), help Bob determine the maximum value he can get from the items in the house.
+Note that Bob can take only one of each item.
+
+All values given will be strictly positive.
+Items will be represented as a list of items.
+Each item will have a weight and value.
+
+For example:
+
+```none
+Items: [
+  { "weight": 5, "value": 10 },
+  { "weight": 4, "value": 40 },
+  { "weight": 6, "value": 30 },
+  { "weight": 4, "value": 50 }
+]
+
+Knapsack Limit: 10
+```
+
+For the above, the first item has weight 5 and value 10, the second item has weight 4 and value 40, and so on.
+
+In this example, Bob should take the second and fourth item to maximize his value, which, in this case, is 90.
+He cannot get more than 90 as his knapsack has a weight limit of 10.

--- a/exercises/practice/knapsack/.meta/config.json
+++ b/exercises/practice/knapsack/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "erikschierboom"
+  ],
+  "files": {
+    "solution": [
+      "knapsack.8th"
+    ],
+    "test": [
+      "test.8th"
+    ],
+    "example": [
+      ".meta/example.8th"
+    ]
+  },
+  "blurb": "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value.",
+  "source": "Wikipedia",
+  "source_url": "https://en.wikipedia.org/wiki/Knapsack_problem"
+}

--- a/exercises/practice/knapsack/.meta/example.8th
+++ b/exercises/practice/knapsack/.meta/example.8th
@@ -2,28 +2,16 @@
   n:1+ [0] swap a:smear
 ;
 
-\ max_weight maximum_values item weight
-: update-max-weight \ n a m n -- n a m
-  >r "weight" m:@ swap "value" m:@ rot r@ swap n:- fourth swap a:@ rot n:+ r@ rot swap a:_@ n:max 2 roll r> rot a:! swap
+: update-maximum-for-item-and-weight \ n a m n -- n a m
+  >r "weight" m:@ swap "value" m:@ rot r@ swap n:- fourth swap a:@ rot n:+ 
+  r@ rot swap a:_@ n:max 2 roll r> rot a:! swap
 ;
 
-\ max_weight maximum_values item
-: max-weight-with-item \ n a m -- n a
-  "weight" m:@ fourth ' update-max-weight -rot loop- drop
+: update-maximum-for-item \ n a m -- n a
+  "weight" m:@ fourth ' update-maximum-for-item-and-weight -rot loop- drop
 ;
 
-\ max_weight items --
 : maximum-value \ n a -- n
-  over maximum-values swap \ max_weight maximum_values items
-  ' max-weight-with-item a:each! drop swap a:_@
+  over maximum-values swap
+  ' update-maximum-for-item a:each! drop swap a:_@
 ;
-
-
-\ int knapsack::maximum_value(int max_weight, const std::vector<Item>& items)
-\ {
-\     std::vector<int> dp(static_cast<std::size_t>(max_weight + 1));
-\     for (auto item: items)
-\         for (auto weight = max_weight; weight >= item.weight; --weight)
-\             dp[weight] = std::max(dp[weight], item.value + dp[weight - item.weight]);
-\     return dp[max_weight];
-\ }

--- a/exercises/practice/knapsack/.meta/example.8th
+++ b/exercises/practice/knapsack/.meta/example.8th
@@ -1,5 +1,5 @@
 : maximum-values \ n -- a
-  n:1+ [0] swap a:smear
+  n:1+ a:new 0 a:push swap a:smear
 ;
 
 : update-maximum-for-item-and-weight \ n a m n -- n a m

--- a/exercises/practice/knapsack/.meta/example.8th
+++ b/exercises/practice/knapsack/.meta/example.8th
@@ -1,0 +1,29 @@
+: maximum-values \ n -- a
+  n:1+ [0] swap a:smear
+;
+
+\ max_weight maximum_values item weight
+: update-max-weight \ n a m n -- n a m
+  >r "weight" m:@ swap "value" m:@ rot r@ swap n:- fourth swap a:@ rot n:+ r@ rot swap a:_@ n:max 2 roll r> rot a:! swap
+;
+
+\ max_weight maximum_values item
+: max-weight-with-item \ n a m -- n a
+  "weight" m:@ fourth ' update-max-weight -rot loop- drop
+;
+
+\ max_weight items --
+: maximum-value \ n a -- n
+  over maximum-values swap \ max_weight maximum_values items
+  ' max-weight-with-item a:each! drop swap a:_@
+;
+
+
+\ int knapsack::maximum_value(int max_weight, const std::vector<Item>& items)
+\ {
+\     std::vector<int> dp(static_cast<std::size_t>(max_weight + 1));
+\     for (auto item: items)
+\         for (auto weight = max_weight; weight >= item.weight; --weight)
+\             dp[weight] = std::max(dp[weight], item.value + dp[weight - item.weight]);
+\     return dp[max_weight];
+\ }

--- a/exercises/practice/knapsack/.meta/example.8th
+++ b/exercises/practice/knapsack/.meta/example.8th
@@ -1,4 +1,4 @@
-: maximum-values \ n -- a
+: zeros \ n -- a
   n:1+ a:new 0 a:push swap a:smear
 ;
 
@@ -12,6 +12,6 @@
 ;
 
 : maximum-value \ n a -- n
-  over maximum-values swap
+  over zeros swap
   ' update-maximum-for-item a:each! drop swap a:_@
 ;

--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -1,0 +1,36 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
+description = "no items"
+include = false
+
+[3993a824-c20e-493d-b3c9-ee8a7753ee59]
+description = "no items"
+reimplements = "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7"
+
+[1d39e98c-6249-4a8b-912f-87cb12e506b0]
+description = "one item, too heavy"
+
+[833ea310-6323-44f2-9d27-a278740ffbd8]
+description = "five items (cannot be greedy by weight)"
+
+[277cdc52-f835-4c7d-872b-bff17bab2456]
+description = "five items (cannot be greedy by value)"
+
+[81d8e679-442b-4f7a-8a59-7278083916c9]
+description = "example knapsack"
+
+[f23a2449-d67c-4c26-bf3e-cde020f27ecc]
+description = "8 items"
+
+[7c682ae9-c385-4241-a197-d2fa02c81a11]
+description = "15 items"

--- a/exercises/practice/knapsack/knapsack.8th
+++ b/exercises/practice/knapsack/knapsack.8th
@@ -1,19 +1,3 @@
-: maximum-values \ n -- a
-  n:1+ [0] swap a:smear
-;
-
-\ max_weight maximum_values item weight
-: update-max-weight \ n a m n -- n a m
-  >r "weight" m:@ swap "value" m:@ rot r@ swap n:- fourth swap a:@ rot n:+ r@ rot swap a:_@ n:max 2 roll r> rot a:! swap
-;
-
-\ max_weight maximum_values item
-: max-weight-with-item \ n a m -- n a
-  "weight" m:@ fourth ' update-max-weight -rot loop- drop
-;
-
-\ max_weight items --
 : maximum-value \ n a -- n
-  over maximum-values swap \ max_weight maximum_values items
-  ' max-weight-with-item a:each! drop swap a:_@
+
 ;

--- a/exercises/practice/knapsack/knapsack.8th
+++ b/exercises/practice/knapsack/knapsack.8th
@@ -1,0 +1,19 @@
+: maximum-values \ n -- a
+  n:1+ [0] swap a:smear
+;
+
+\ max_weight maximum_values item weight
+: update-max-weight \ n a m n -- n a m
+  >r "weight" m:@ swap "value" m:@ rot r@ swap n:- fourth swap a:@ rot n:+ r@ rot swap a:_@ n:max 2 roll r> rot a:! swap
+;
+
+\ max_weight maximum_values item
+: max-weight-with-item \ n a m -- n a
+  "weight" m:@ fourth ' update-max-weight -rot loop- drop
+;
+
+\ max_weight items --
+: maximum-value \ n a -- n
+  over maximum-values swap \ max_weight maximum_values items
+  ' max-weight-with-item a:each! drop swap a:_@
+;

--- a/exercises/practice/knapsack/libs/exercism/test
+++ b/exercises/practice/knapsack/libs/exercism/test
@@ -1,0 +1,173 @@
+needs console/loaded
+
+\ -----------------------------------------------------------------
+
+ns: test
+
+-1 var, test-count
+var tests-passed
+var tests-failed
+var tests-skipped
+true var, run-test
+
+\ Some utility words
+
+
+: test-passed \ s x x --   \\ test name, expected value, actual value
+    2drop
+    1 tests-passed n:+!
+    con:green con:onBlack . space " ... OK" . con:white con:onBlack cr
+;
+
+: test-skipped \ s --
+    1 tests-skipped n:+!
+    con:cyan con:onBlack . space " ... SKIPPED" . con:white con:onBlack cr
+;
+
+: test-failed \ s x x --   \\ test name, expected value, actual value
+    1 tests-failed n:+!
+    rot
+    con:red con:onBlack . space " ... FAIL" . con:white con:onBlack cr
+    "    Actual:    «" . . "»" . cr
+    "    Expected:  «" . . "»" . cr cr
+;
+
+: isword?  \ x -- x f
+   dup  >kind  ns:w   n:= 
+;
+
+: run-test? \ -- T
+   run-test @ if true else "RUN_ALL_TESTS" getenv n:>bool then
+;
+
+\ Num passed + num skipped + num failed should == num tests
+: all-tests-run? \ -- T
+    tests-passed @ tests-skipped @ tests-failed @ n:+ n:+
+    test-count @ n:=
+;
+
+\ returns true if x is a date, false otherwise
+: date? \ x -- x T
+    dup >kind ns:d n:=
+;
+
+\ adapted from 8th forum -- https://8th-dev.com/forum/index.php/topic,2745.0.html
+: eq? \ x x -- T
+   \ are the items the same kind?
+   2dup >kind swap >kind n:=
+   !if 2drop false ;then
+
+   \ same kind: try different comparators
+   number? if n:= ;then
+   string? if s:= ;then
+   array?  if ' eq? a:= 2nip ;then
+   map?    if ' eq? m:= 2nip ;then
+   date?   if d:= ;then
+
+   \ otherwise fall back to 'lazy evaluation'
+   l: =
+;
+
+: eps_eq? \ n x x -- T
+   \ are the items the same kind?
+   2dup >kind swap >kind n:=
+   !if 2drop false ;then
+   number? !if 2drop false ;then  
+   rot n:~=
+;
+
+: check-depth \ ... n -- ...
+  dup>r
+  n:1+ depth n:=
+  !if
+    con:red con:onBlack 
+    "PANIC: expected stack depth to be " . r> . cr
+    "Stack is:" . cr
+    .s cr
+    255 die
+  then
+  rdrop
+;
+
+\ -----------------------------------------------------------------
+
+\ status report at end of run
+( all-tests-run?  
+  !if con:red con:onBlack "... FAIL - not all tests completed" . con:white con:onBlack cr then
+) onexit
+
+\ Print a summary of the tests run
+( con:white con:onBlack
+  test-count   @ . space "tests planned - " .
+  tests-passed @ . space "passed - " .
+  tests-skipped @ . space "skipped - " .
+  tests-failed @ . space "failed" . cr
+) onexit
+
+\ -----------------------------------------------------------------
+\ The public-facing words
+\ -----------------------------------------------------------------
+    
+: equal? \ s x w -- | s w x --
+   run-test? !if 2drop test-skipped ;; then
+   isword? !if swap then
+   w:exec
+   3 check-depth
+   2dup             \ so test-failed can show actual and expected
+   eq? if test-passed else test-failed then
+;
+
+: approx_equal? \ s x w n -- | s w x n --
+   run-test? !if 3drop test-skipped ;; then
+   -rot isword? !if swap then
+   w:exec
+   4 check-depth
+   3dup            \ so test-failed can show actual and expected
+   eps_eq?
+   if rot drop test-passed else rot drop test-failed then
+;
+
+: true? \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   2 check-depth
+   true swap dup    \ so test-failed can show actual and expected
+   if test-passed else test-failed then 
+;
+
+: false? \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   2 check-depth
+   false swap dup    \ so test-failed can show actual and expected
+   !if test-passed else test-failed then 
+;
+
+: null? \ s w --
+   run-test? !if drop test-skipped ;; then
+   w:exec
+   2 check-depth
+   null swap dup     \ so test-failed can show actual and expected
+   G:null? nip if test-passed else test-failed then 
+;
+
+: SKIP-REST-OF-TESTS false run-test ! ;
+
+: tests \ n -- 
+    test-count ! 
+;
+
+\ Set the exit status:
+\   0 = all OK
+\   1 = not all tests were run (some error occurred)
+\   2 = some tests failed
+: end-of-tests \ --
+    all-tests-run?
+    if
+      tests-failed @ 0 n:= if 0 else 2 then
+    else
+      1
+    then
+    die
+;
+

--- a/exercises/practice/knapsack/test.8th
+++ b/exercises/practice/knapsack/test.8th
@@ -1,0 +1,44 @@
+"knapsack.8th" f:include
+needs exercism/test
+with: test
+7 tests
+
+"no items"
+    ( 100 [] maximum-value )
+    0
+    equal?
+
+SKIP-REST-OF-TESTS
+
+"one item, too heavy"
+    ( 10 [{"weight": 100, "value": 1}] maximum-value )
+    0
+    equal?
+
+"five items (cannot be greedy by weight)"
+    ( 10 [{"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 10, "value": 21}] maximum-value )
+    21
+    equal?
+
+"five items (cannot be greedy by value)"
+    ( 10 [{"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 10, "value": 50}] maximum-value )
+    80
+    equal?
+
+"example knapsack"
+    ( 10 [{"weight": 5, "value": 10}, {"weight": 4, "value": 40}, {"weight": 6, "value": 30}, {"weight": 4, "value": 50}] maximum-value )
+    90
+    equal?
+
+"8 items"
+    ( 104 [{"weight": 25, "value": 350}, {"weight": 35, "value": 400}, {"weight": 45, "value": 450}, {"weight": 5, "value": 20}, {"weight": 25, "value": 70}, {"weight": 3, "value": 8}, {"weight": 2, "value": 5}, {"weight": 2, "value": 5}] maximum-value )
+    900
+    equal?
+
+"15 items"
+    ( 750 [{"weight": 70, "value": 135}, {"weight": 73, "value": 139}, {"weight": 77, "value": 149}, {"weight": 80, "value": 150}, {"weight": 82, "value": 156}, {"weight": 87, "value": 163}, {"weight": 90, "value": 173}, {"weight": 94, "value": 184}, {"weight": 98, "value": 192}, {"weight": 106, "value": 201}, {"weight": 110, "value": 210}, {"weight": 113, "value": 214}, {"weight": 115, "value": 221}, {"weight": 118, "value": 229}, {"weight": 120, "value": 240}] maximum-value )
+    1458
+    equal?
+
+end-of-tests
+;with


### PR DESCRIPTION
Another weird one. When I run the test code in a REPL, they're fine:

For example

```
"example.8th" f:include G:reset  10 [{"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 2, "value": 5}, {"weight": 10, "value": 21}] maximum-value .s
 0 n: 000000010c6f4e50 2  21
```

and

```
"example.8th" f:include G:reset 10 [{"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 2, "value": 20}, {"weight": 10, "value": 50}] maximum-value .s
 0 n: 000000010c6f4a90 3  80
 ```

But when I run `bin/test-no-docker -r knapsack` the tests fail. I see two possible problems:

- Working with maps somehow trips things up, as I also suspected this to fail `food-chain`
- Our test library messes things up when using maps

I'm at a loss how to fix it. Could you please take a look?