### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/meetup/.docs/instructions.append.md
+++ b/exercises/practice/meetup/.docs/instructions.append.md
@@ -1,7 +1,5 @@
 # Instructions append
 
-# Date words
+## Date words
 
-~~~~exercism/note
 The `d` namespace contains date and time related words, some of which will be really useful to solve this exercise.
-~~~~


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.